### PR TITLE
Bug Fix: Datatype error at ExtendedContactDetail.bal

### DIFF
--- a/r5/Dependencies.toml
+++ b/r5/Dependencies.toml
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.12.8"
+version = "2.12.9"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/r5/datatype_extended_contact_detail.bal
+++ b/r5/datatype_extended_contact_detail.bal
@@ -74,8 +74,8 @@
 }
 public type ExtendedContactDetail record {|
     CodeableConcept purpose?;
-    HumanName name?;
-    ContactPoint telecom?;
+    HumanName[] name?;
+    ContactPoint[] telecom?;
     Address address?;
     Reference organization?;
     Period period?;


### PR DESCRIPTION
## Purpose
This PR is related to [FHIR F5 Tool Support]( https://github.com/wso2-enterprise/open-healthcare/issues/1734)
Fixes the package and template generation issue for the FHIR R5 ExtendedContactDetail datatype, where HumanName and ContactPoint were incorrectly defined. Resolves: https://github.com/ballerina-platform/module-ballerinax-health.fhir.r5/blob/main/r5/datatype_extended_contact_detail.bal

## Goals
Update the Ballerina type definitions to use arrays of HumanName and ContactPoint as per the R5 FHIR specification.

## Approach
Modified the datatype_extended_contact_detail.bal file in the R5 directory to change the types of HumanName and ContactPoint from string to HumanName[] and ContactPoint[].

## User Stories
N/A

## Release Note
Fixed the generation of the ExtendedContactDetail datatype in FHIR R5 by updating the types of HumanName and ContactPoint to arrays.

## Documentation
N/A – This is a bug fix and does not impact documentation.

## Training
N/A

## Certification
N/A – No impact on certification exams.

## Marketing
N/A

## Automation Tests
Code Coverage
Main Class (FHIRPackageGenHandler): 100%  Methods 73% Lines

## Security Checks
- Followed WSO2 Secure Coding Guidelines
- No secrets (keys, passwords, tokens, etc.) committed

## Samples
Listing Profiles Implemented with FHIR R5 which are tested as of 15th May 2025:
- https://fhir.hl7.at/HL7-AT-FHIR-Core-R5/ 
- https://registry.fhir.org/package/ee.fhir.base%7C1.1.1
- https://registry.fhir.org/package/hl7.fhir.eu.base-r5%7C0.1.0-ballot

## Related PRs
To be published in fhir-tools repository and open-healthcare-codegentool-framework

## Migrations
N/A

## Test Environment
JDK 17
Windows 11 Pro
Ballerina 2201.10.2

## Learning
https://hl7.org/fhir/R5/datatypes.html#HumanName
https://hl7.org/fhir/R5/datatypes.html#ContactPoint