### PR TITLE
[FHIR-R5-LIB] [Bug Fix] Parsing Error for Extended Element Arrays Inside Base Elements

### DIFF
--- a/r5/datatype_element.bal
+++ b/r5/datatype_element.bal
@@ -47,5 +47,5 @@
 public type Element record {|
     string id?;
     Extension[] extension?;
-    Element ...;
+    Element | Element[]...;
 |};


### PR DESCRIPTION
## Purpose
This PR is related to [Parsing Error for Extended Element Arrays Inside Base Elements](https://github.com/ballerina-platform/ballerina-library/issues/7949). 

## Goals
To fix the parsing error occurring, when there is an extended element array, instead of a plain element, in the second level of a base type.

## Approach
The logics of the existing health-tool couldn't parse the below resource snippet from FHIR R5 ATCore (Austria) profiles.
```
"address" : [{
    "use" : "home",
    "line" : ["Landstrasse 5 Stock 3 Tür 5"],
    "_line" : [{
      "extension" : [{
        "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
        "valueString" : "Landstrasse"
      },
      {
        "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
        "valueString" : "5"
      },
      {
        "url" : "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-additionalLocator",
        "valueString" : "Stock 3 Tür 5"
      },
      {
        "url" : "http://hl7.at/fhir/HL7ATCoreProfiles/5.0.0/StructureDefinition/at-core-ext-address-additionalInformation",
        "valueString" : "Lift vorhanden"
      }]
}];
```
Here the _line element has an array of extended element not a typical single element.

As array of extend elements are not restricted by FHIR definitions itself, the record for **Element** was changed to have UNION spread operator.
```
public type Element record {|
    string id?;
    Extension[] extension?;
    Element | Element[]...;
|};
```
Now even though the "Element" type is assigned by the tool, a user can parse second level extended element arrays without an issue.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
Tested with local push and verified the change doesn't affect any existing package generations.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes
 - Ran FindSecurityBugs plugin and verified report? No
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
N/A

## Related PRs
[Add FHIR R5 Support](https://github.com/wso2-enterprise/open-healthcare/issues/1734)

## Migrations (if applicable)
Java: 21
Ballerina: 2201.12.3

## Test environment
JDK: 21
Ballerina: 2201.12.3
OS: Windows 11 Pro
 
## Learning
N/A