### PR TITLE
Add missing part type to international500 resource_parameters.bal

### DIFF
--- a/international500/Dependencies.toml
+++ b/international500/Dependencies.toml
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "health.base"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},
@@ -311,7 +311,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "health.fhir.r5"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},

--- a/international500/resource_parameters.bal
+++ b/international500/resource_parameters.bal
@@ -156,6 +156,7 @@ public type Parameters record {|
 # + valueDuration - Conveys the content if the parameter is a data type.
 # + valueDataRequirement - Conveys the content if the parameter is a data type.
 # + valueAnnotation - Conveys the content if the parameter is a data type.
+# + part - Parts of a nested Parameter.
 @r5:DataTypeDefinition {
     name: "ParametersParameter",
     baseType: (),
@@ -690,6 +691,15 @@ public type Parameters record {|
             isArray: false,
             description: "Conveys the content if the parameter is a data type.",
             path: "Parameters.parameter.value[x]"
+        },
+        "part": {
+            name: "part",
+            dataType: ParametersParameter,
+            min: 0,
+            max: int:MAX_VALUE,
+            isArray: true,
+            description: "Parts of a nested Parameter.",
+            path: "Parameters.parameter.part"
         }
     },
     serializers: {
@@ -759,5 +769,5 @@ public type ParametersParameter record {|
     r5:Duration valueDuration?;
     r5:DataRequirement valueDataRequirement?;
     r5:Annotation valueAnnotation?;
+    ParametersParameter[] part?;
 |};
-


### PR DESCRIPTION
## Purpose
> This PR adds the missing ```part?``` parameter to the ```ParameterParameters``` type.

According to https://hl7.org/fhir/R5/parameters.html#XParameters.parameter, this parameter should be there.

